### PR TITLE
Add short_names_server for better experience with weechat-matrix

### DIFF
--- a/highmon.pl
+++ b/highmon.pl
@@ -1,6 +1,5 @@
 #
 # highmon.pl - Highlight Monitoring for weechat 0.3.0
-# Version 2.6
 #
 # Add 'Highlight Monitor' buffer/bar to log all highlights in one spot
 #
@@ -73,6 +72,8 @@
 # Bugs and feature requests at: https://github.com/KenjiE20/highmon
 
 # History:
+# 2020-06-21, Sebastien Helleu <flashcode@flashtux.org>:
+#	v2.7: make call to bar_new compatible with WeeChat >= 2.9
 # 2019-05-13, HubbeKing <hubbe128@gmail.com>
 #	v2.6:	-add: send "logger_backlog" signal on buffer open if logging is enabled
 # 2014-08-16, KenjiE20 <longbow@longbowslair.co.uk>:
@@ -266,7 +267,14 @@ sub highmon_bar_open
 	# Make the bar item
 	weechat::bar_item_new("highmon", "highmon_bar_build", "");
 
-	$highmon_bar = weechat::bar_new ("highmon", "off", 100, "root", "", "bottom", "vertical", "vertical", 0, 0, "default", "cyan", "default", "on", "highmon");
+        if (weechat::info_get("version_number", "") >= 0x02090000)
+        {
+            $highmon_bar = weechat::bar_new ("highmon", "off", 100, "root", "", "bottom", "vertical", "vertical", 0, 0, "default", "cyan", "default", "default", "on", "highmon");
+        }
+        else
+        {
+            $highmon_bar = weechat::bar_new ("highmon", "off", 100, "root", "", "bottom", "vertical", "vertical", 0, 0, "default", "cyan", "default", "on", "highmon");
+        }
 
 	return weechat::WEECHAT_RC_OK;
 }
@@ -717,7 +725,7 @@ sub highmon_new_message
 	if ($cb_high == "1" || (weechat::config_get_plugin("merge_private") eq "on" && $cb_tags =~ /notify_private/))
 	{
 		# Pre bug #29618 (0.3.3) away detect
-		if (weechat::info_get("version_number", "") <= 197120)
+		if (weechat::info_get("version_number", "") <= 0x00030200)
 		{
 			$away = '';
 			# Get infolist for this server
@@ -1131,7 +1139,7 @@ sub format_buffer_name
 }
 
 # Check result of register, and attempt to behave in a sane manner
-if (!weechat::register("highmon", "KenjiE20", "2.6", "GPL3", "Highlight Monitor", "", ""))
+if (!weechat::register("highmon", "KenjiE20", "2.7", "GPL3", "Highlight Monitor", "", ""))
 {
 	# Double load
 	weechat::print ("", "\tHighmon is already loaded");

--- a/highmon.pl
+++ b/highmon.pl
@@ -27,6 +27,10 @@
 # /set plugins.var.perl.highmon.short_names
 #  Setting this to 'on' will trim the network name from highmon, ala buffers.pl
 #
+# /set plugins.var.perl.highmon.short_names_server
+#  Setting 'short_names' and this to 'on' will show both network name and buffer short_name.
+#  Useful in combination with plugins that use machine-readable full names like weechat-matrix.
+#
 # /set plugins.var.perl.highmon.merge_private
 #  Setting this to 'on' will merge private messages to highmon's display
 #
@@ -74,6 +78,7 @@
 # History:
 # 2021-05-25, Tomas Janousek <tomi@nomi.cz:
 #	v2.8:	-refactor: reduce code duplication in format_buffer_name
+#			-add: short_names_server for better experience with weechat-matrix
 # 2020-06-21, Sebastien Helleu <flashcode@flashtux.org>:
 #	v2.7: make call to bar_new compatible with WeeChat >= 2.9
 # 2019-05-13, HubbeKing <hubbe128@gmail.com>
@@ -176,6 +181,10 @@ $highmonhelp = weechat::color("bold")."/highmon [help] | [monitor [channel [serv
 
 ".weechat::color("bold")."/set plugins.var.perl.highmon.short_names".weechat::color("-bold")."
  Setting this to 'on' will trim the network name from highmon, ala buffers.pl
+
+".weechat::color("bold")."/set plugins.var.perl.highmon.short_names_server".weechat::color("-bold")."
+ Setting 'short_names' and this to 'on' will show both network name and buffer short_name.
+ Useful in combination with plugins that use machine-readable full names like weechat-matrix.
 
 ".weechat::color("bold")."/set plugins.var.perl.highmon.merge_private".weechat::color("-bold")."
  Setting this to 'on' will merge private messages to highmon's display
@@ -522,6 +531,12 @@ sub highmon_config_init
 	if (!(weechat::config_is_set_plugin ("short_names")))
 	{
 		weechat::config_set_plugin("short_names", "off");
+	}
+
+	# Short names + server default
+	if (!(weechat::config_is_set_plugin ("short_names_server")))
+	{
+		weechat::config_set_plugin("short_names_server", "off");
 	}
 
 	# Coloured names default
@@ -1063,6 +1078,10 @@ sub format_buffer_name
 	if (weechat::config_get_plugin("merge_private") eq "on" && weechat::buffer_get_string($cb_bufferp, "localvar_type") eq "private")
 	{
 		$bufname = weechat::buffer_get_string($cb_bufferp, "localvar_server");
+	}
+	elsif (weechat::config_get_plugin("short_names") eq "on" and weechat::config_get_plugin("short_names_server") eq "on")
+	{
+		$bufname = weechat::buffer_get_string($cb_bufferp, "localvar_server") . weechat::buffer_get_string($cb_bufferp, 'short_name');
 	}
 	# Format name to short or 'nicename'
 	elsif (weechat::config_get_plugin("short_names") eq "on")

--- a/highmon.pl
+++ b/highmon.pl
@@ -1131,7 +1131,7 @@ sub format_buffer_name
 }
 
 # Check result of register, and attempt to behave in a sane manner
-if (!weechat::register("highmon", "KenjiE20", "2.5", "GPL3", "Highlight Monitor", "", ""))
+if (!weechat::register("highmon", "KenjiE20", "2.6", "GPL3", "Highlight Monitor", "", ""))
 {
 	# Double load
 	weechat::print ("", "\tHighmon is already loaded");

--- a/highmon.pl
+++ b/highmon.pl
@@ -115,11 +115,11 @@
 #		-code change: Made more subs to shrink the code down in places
 #		-fix: Stop highmon attempting to double load/hook
 #		-fix: Add version dependant check for away status
-# 2010-01-25, KenjiE20 <longbow@longbowslair.co.uk>: 
-#       v1.7:   -fixture: Let highmon be aware of nick_prefix/suffix 
-#                       and allow custom prefix/suffix for chanmon buffer 
-#                       (Defaults to <> if nothing set, and blank if there is) 
-#               (Thanks to m4v for these) 
+# 2010-01-25, KenjiE20 <longbow@longbowslair.co.uk>:
+#       v1.7:   -fixture: Let highmon be aware of nick_prefix/suffix
+#                       and allow custom prefix/suffix for chanmon buffer
+#                       (Defaults to <> if nothing set, and blank if there is)
+#               (Thanks to m4v for these)
 # 2009-09-07, KenjiE20 <longbow@longbowslair.co.uk>:
 #	v1.6:	-feature: colored buffer names
 #		-change: version sync with chanmon
@@ -243,12 +243,12 @@ sub highmon_bar_build
 			# Find max align needed
 			$prefix_num = (index(weechat::string_remove_color($_, ""), $sep));
 			$align_num = $prefix_num if ($prefix_num > $align_num);
-		}		
+		}
 		foreach(@bar_lines)
 		{
 			# Get align for this line
 			$prefix_num = (index(weechat::string_remove_color($_, ""), $sep));
-			
+
 			# Make string
 			$str = $str.$bar_lines_time[$count]." ".(" " x ($align_num - $prefix_num)).$_."\n";
 			# Increment count for sync with time list
@@ -260,10 +260,10 @@ sub highmon_bar_build
 
 # Make a new bar
 sub highmon_bar_open
-{	
+{
 	# Make the bar item
 	weechat::bar_item_new("highmon", "highmon_bar_build", "");
-		
+
 	$highmon_bar = weechat::bar_new ("highmon", "off", 100, "root", "", "bottom", "vertical", "vertical", 0, 0, "default", "cyan", "default", "on", "highmon");
 
 	return weechat::WEECHAT_RC_OK;
@@ -278,7 +278,7 @@ sub highmon_bar_close
 	{
 		weechat::bar_remove($highmon_bar);
 	}
-	
+
 	# Find if bar item exists
 	$highmon_bar_item = weechat::bar_item_search("highmon_bar");
 	# If is does, close it
@@ -286,7 +286,7 @@ sub highmon_bar_close
 	{
 		weechat::bar_remove($highmon_bar_item);
 	}
-	
+
 	@bar_lines = ();
 	return weechat::WEECHAT_RC_OK;
 }
@@ -345,7 +345,7 @@ sub highmon_command_cb
 	$args = $_[2];
 	my $cmd = '';
 	my $arg = '';
-	
+
 	if ($args ne "")
 	{
 		# Split argument up
@@ -358,14 +358,14 @@ sub highmon_command_cb
 			$arg = join(" ", @arg_array);
 		}
 	}
-	
+
 	# Help command
 	if ($cmd eq "" || $cmd eq "help")
 	{
 		print_help();
 	}
 	# /monitor command
-	elsif ($cmd eq "monitor") 
+	elsif ($cmd eq "monitor")
 	{
 		highmon_toggle($data, $buffer, $arg);
 	}
@@ -400,14 +400,14 @@ sub highmon_config_clean
 	$data = $_[0];
 	$buffer = $_[1];
 	$args = $_[2];
-	
+
 	# Don't do anything if bad option given
 	if ($args ne "default" && $args ne "orphan"  && $args ne "all")
 	{
 		weechat::print("", "\thighmon.pl: Unknown option");
 		return weechat::WEECHAT_RC_OK;
 	}
-	
+
 	@chans = ();
 	# Load an infolist of highmon options
 	$infolist = weechat::infolist_get("option", "", "*highmon*");
@@ -500,25 +500,25 @@ sub highmon_config_init
 	{
 		weechat::config_set_plugin("alignment", "none");
 	}
-	
+
 	# Short name default
 	if (!(weechat::config_is_set_plugin ("short_names")))
 	{
 		weechat::config_set_plugin("short_names", "off");
 	}
-	
+
 	# Coloured names default
 	if (!(weechat::config_is_set_plugin ("color_buf")))
 	{
 		weechat::config_set_plugin("color_buf", "on");
 	}
-	
+
 	# Hotlist show default
 	if (!(weechat::config_is_set_plugin ("hotlist_show")))
 	{
 		weechat::config_set_plugin("hotlist_show", "off");
 	}
-	
+
 	# Away only default
 	if (!(weechat::config_is_set_plugin ("away_only")))
 	{
@@ -530,13 +530,13 @@ sub highmon_config_init
 	{
 		weechat::config_set_plugin("logging", "off");
 	}
-	
+
 	# Output default
 	if (!(weechat::config_is_set_plugin ("output")))
 	{
 		weechat::config_set_plugin("output", "buffer");
 	}
-	
+
 	# Private message merging
 	if (!(weechat::config_is_set_plugin ("merge_private")))
 	{
@@ -594,9 +594,9 @@ sub highmon_config_cb
 	$point = $_[0];
 	$name = $_[1];
 	$value = $_[2];
-	
+
 	$name =~ s/^plugins\.var\.perl\.highmon\.//;
-	
+
 	# Set logging on buffer
 	if ($name eq "logging")
 	{
@@ -623,7 +623,7 @@ sub highmon_config_cb
 			{
 				weechat::buffer_close($highmon_buffer)
 			}
-			
+
 			# Output bar lines default
 			if (!(weechat::config_is_set_plugin ("bar_lines")))
 			{
@@ -643,7 +643,7 @@ sub highmon_config_cb
 			# Open buffer
 			highmon_buffer_open();
 		}
-	
+
 	}
 	# Change if hotlist config changes
 	elsif ($name eq "hotlist_show")
@@ -676,9 +676,9 @@ sub highmon_hook
 {
 	weechat::hook_print("", "", "", 0, "highmon_new_message", "");
 	weechat::hook_command("highclean", "Highmon config clean up", "default|orphan|all", " default: Cleans all config entries with the default \"on\" value\n  orphan: Cleans all config entries for channels you aren't currently joined\n     all: Does both defaults and orphan", "default|orphan|all", "highmon_config_clean", "");
-	
+
 	weechat::hook_command("highmon", "Highmon help", "[help] | [monitor [channel [server]]] | [clean default|orphan|all] | clearbar", "    help: Print help on config options for highmon\n monitor: Toggles monitoring for a channel\n   clean: Highmon config clean up (/highclean)\nclearbar: Clear Highmon bar", "help || monitor %(irc_channels) %(irc_servers) || clean default|orphan|all || clearbar", "highmon_command_cb", "");
-	
+
 	weechat::hook_config("plugins.var.perl.highmon.*", "highmon_config_cb", "");
 	weechat::hook_config("weechat.look.prefix_suffix", "highmon_config_cb", "");
 }
@@ -783,13 +783,13 @@ sub highmon_print
 	my $nick = $_[2] if ($_[2]);
 	my $cb_date = $_[3] if ($_[3]);
 	my $cb_tags = $_[4] if ($_[4]);
-	
+
 	#Normal channel message
 	if ($cb_bufferp && $nick)
 	{
 		# Format buffer name
-		$bufname = format_buffer_name($cb_bufferp);	
-	
+		$bufname = format_buffer_name($cb_bufferp);
+
 		# If alignment is #channel | nick msg
 		if (weechat::config_get_plugin("alignment") eq "channel")
 		{
@@ -848,8 +848,8 @@ sub highmon_print
 	elsif ($cb_bufferp && !$nick)
 	{
 		# Format buffer name
-		$bufname = format_buffer_name($cb_bufferp);	
-		
+		$bufname = format_buffer_name($cb_bufferp);
+
 		# If alignment is #channel * | *
 		if (weechat::config_get_plugin("alignment") =~ /channel/)
 		{
@@ -878,7 +878,7 @@ sub highmon_print
 	{
 		$outstr = "\t".$cb_msg;
 	}
-	
+
 	# Send string to buffer
 	if (weechat::config_get_plugin("output") eq "buffer")
 	{
@@ -924,11 +924,11 @@ sub highmon_print
 		}
 		# Push updates to bar lists
 		push (@bar_lines_time, $time);
-		
+
 		# Change tab char
 		$delim = " ".weechat::color(weechat::config_string(weechat::config_get("weechat.color.chat_delimiters"))).weechat::config_string(weechat::config_get("weechat.look.prefix_suffix")).weechat::color("reset")." ";
 		$outstr =~ s/\t/$delim/;
-		
+
 		push (@bar_lines, $outstr);
 		# Trigger update
 		weechat::bar_item_update("highmon");
@@ -959,7 +959,7 @@ sub highmon_toggle
 	$data = $_[0];
 	$buffer = $_[1];
 	$args = $_[2];
-	
+
 	# Check if we've been told what channel to act on
 	if ($args ne "")
 	{
@@ -1028,7 +1028,7 @@ sub highmon_toggle
 		{
 			# If currently on, set off
 			weechat::config_set_plugin($bufname, "off");
-			
+
 			# Send to output formatter
 			highmon_print("Highlight Monitoring Disabled", $bufp);
 			return weechat::WEECHAT_RC_OK;
@@ -1041,7 +1041,7 @@ sub format_buffer_name
 {
 	$cb_bufferp = $_[0];
 	$bufname = weechat::buffer_get_string($cb_bufferp, 'name');
-	
+
 	# Set colour from buffer name
 	if (weechat::config_get_plugin("color_buf") eq "on")
 	{
@@ -1061,7 +1061,7 @@ sub format_buffer_name
 			$color = weechat::config_string($color);
 			$color = weechat::color($color);
 		}
-		
+
 		# Private message just show network
 		if (weechat::config_get_plugin("merge_private") eq "on" && weechat::buffer_get_string($cb_bufferp, "localvar_type") eq "private")
 		{
@@ -1076,7 +1076,7 @@ sub format_buffer_name
 		{
 			$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
 		}
-		
+
 		# Build a coloured string
 		$bufname = $color.$bufname.weechat::color("reset");
 	}
@@ -1097,7 +1097,7 @@ sub format_buffer_name
 		{
 			$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
 		}
-	
+
 		$color = weechat::config_get_plugin("color_buf");
 		$bufname = weechat::color($color).$bufname.weechat::color("reset");
 	}
@@ -1119,7 +1119,7 @@ sub format_buffer_name
 			$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
 		}
 	}
-	
+
 	return $bufname;
 }
 

--- a/highmon.pl
+++ b/highmon.pl
@@ -72,6 +72,8 @@
 # Bugs and feature requests at: https://github.com/KenjiE20/highmon
 
 # History:
+# 2021-05-25, Tomas Janousek <tomi@nomi.cz:
+#	v2.8:	-refactor: reduce code duplication in format_buffer_name
 # 2020-06-21, Sebastien Helleu <flashcode@flashtux.org>:
 #	v2.7: make call to bar_new compatible with WeeChat >= 2.9
 # 2019-05-13, HubbeKing <hubbe128@gmail.com>
@@ -1057,6 +1059,21 @@ sub format_buffer_name
 	$cb_bufferp = $_[0];
 	$bufname = weechat::buffer_get_string($cb_bufferp, 'name');
 
+	# Private message just show network
+	if (weechat::config_get_plugin("merge_private") eq "on" && weechat::buffer_get_string($cb_bufferp, "localvar_type") eq "private")
+	{
+		$bufname = weechat::buffer_get_string($cb_bufferp, "localvar_server");
+	}
+	# Format name to short or 'nicename'
+	elsif (weechat::config_get_plugin("short_names") eq "on")
+	{
+		$bufname = weechat::buffer_get_string($cb_bufferp, 'short_name');
+	}
+	else
+	{
+		$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
+	}
+
 	# Set colour from buffer name
 	if (weechat::config_get_plugin("color_buf") eq "on")
 	{
@@ -1077,69 +1094,21 @@ sub format_buffer_name
 			$color = weechat::color($color);
 		}
 
-		# Private message just show network
-		if (weechat::config_get_plugin("merge_private") eq "on" && weechat::buffer_get_string($cb_bufferp, "localvar_type") eq "private")
-		{
-			$bufname = weechat::buffer_get_string($cb_bufferp, "localvar_server");
-		}
-		# Format name to short or 'nicename'
-		elsif (weechat::config_get_plugin("short_names") eq "on")
-		{
-			$bufname = weechat::buffer_get_string($cb_bufferp, 'short_name');
-		}
-		else
-		{
-			$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
-		}
-
 		# Build a coloured string
 		$bufname = $color.$bufname.weechat::color("reset");
 	}
 	# User set colour name
 	elsif (weechat::config_get_plugin("color_buf") ne "off")
 	{
-		# Private message just show network
-		if (weechat::config_get_plugin("merge_private") eq "on" && weechat::buffer_get_string($cb_bufferp, "localvar_type") eq "private")
-		{
-			$bufname = weechat::buffer_get_string($cb_bufferp, "localvar_server");
-		}
-		# Format name to short or 'nicename'
-		elsif (weechat::config_get_plugin("short_names") eq "on")
-		{
-			$bufname = weechat::buffer_get_string($cb_bufferp, 'short_name');
-		}
-		else
-		{
-			$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
-		}
-
 		$color = weechat::config_get_plugin("color_buf");
 		$bufname = weechat::color($color).$bufname.weechat::color("reset");
-	}
-	# Stick with default colour
-	else
-	{
-		# Private message just show network
-		if (weechat::config_get_plugin("merge_private") eq "on" && weechat::buffer_get_string($cb_bufferp, "localvar_type") eq "private")
-		{
-			$bufname = weechat::buffer_get_string($cb_bufferp, "localvar_server");
-		}
-		# Format name to short or 'nicename'
-		elsif (weechat::config_get_plugin("short_names") eq "on")
-		{
-			$bufname = weechat::buffer_get_string($cb_bufferp, 'short_name');
-		}
-		else
-		{
-			$bufname =~ s/(.*)\.([#&\+!])(.*)/$1$2$3/;
-		}
 	}
 
 	return $bufname;
 }
 
 # Check result of register, and attempt to behave in a sane manner
-if (!weechat::register("highmon", "KenjiE20", "2.7", "GPL3", "Highlight Monitor", "", ""))
+if (!weechat::register("highmon", "KenjiE20", "2.8", "GPL3", "Highlight Monitor", "", ""))
 {
 	# Double load
 	weechat::print ("", "\tHighmon is already loaded");

--- a/highmon.pl
+++ b/highmon.pl
@@ -1,6 +1,6 @@
 #
 # highmon.pl - Highlight Monitoring for weechat 0.3.0
-# Version 2.5
+# Version 2.6
 #
 # Add 'Highlight Monitor' buffer/bar to log all highlights in one spot
 #
@@ -73,6 +73,8 @@
 # Bugs and feature requests at: https://github.com/KenjiE20/highmon
 
 # History:
+# 2019-05-13, HubbeKing <hubbe128@gmail.com>
+#	v2.6:	-add: send "logger_backlog" signal on buffer open if logging is enabled
 # 2014-08-16, KenjiE20 <longbow@longbowslair.co.uk>:
 #	v2.5:	-add: clearbar command to clear bar output
 #			-add: firstrun output prompt to check the help text for set up hints as they were being missed
@@ -306,7 +308,7 @@ sub highmon_buffer_open
 	# Turn off notify, highlights
 	if ($highmon_buffer ne "")
 	{
-		if (weechat::config_get_plugin("hotlist_show" eq "off"))
+		if (weechat::config_get_plugin("hotlist_show") eq "off")
 		{
 			weechat::buffer_set($highmon_buffer, "notify", "0");
 		}
@@ -316,6 +318,11 @@ sub highmon_buffer_open
 		if (weechat::config_get_plugin("logging") eq "off")
 		{
 			weechat::buffer_set($highmon_buffer, "localvar_set_no_log", "1");
+		}
+		# send "logger_backlog" signal if logging is enabled to display backlog
+		if (weechat::config_get_plugin("logging") eq "on")
+		{
+			weechat::hook_signal_send("logger_backlog", weechat::WEECHAT_HOOK_SIGNAL_POINTER, $highmon_buffer)
 		}
 	}
 	return weechat::WEECHAT_RC_OK;


### PR DESCRIPTION
The motivation here is that weechat-matrix uses machine-readable room ids as full names that aren't human friendly. It does offer an option to use human-readable full names, but these are neither unique nor stable, causing trouble with logging. Therefore I figured that the best way to fix this is to optionally use server names in highmon.pl and let weechat-matrix use the unique room ids.

A similar patch has already been merged for go.py: https://github.com/weechat/scripts/commit/414cff3ee605ba204b607742430a21443c035b08

---

- [ ] merge https://github.com/KenjiE20/highmon/pull/13 before this